### PR TITLE
Added fix so `npm start` works on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react-scripts": "1.0.7"
   },
   "scripts": {
-    "start": "PORT=4000 react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",


### PR DESCRIPTION
Issue details here: https://github.com/davidmfoley/react-router-modal-examples/issues/1#issue-436442873

The old `npm start` contained `PORT=4000`, which is a Unix command that didn't work on Windows. I removed this part and made the `npm start` identical to that in the `create-react-app` package, which seemed to work on my Windows 10 machine.

Since this project was bootstraped with CRA, it seems like this change should be OK.

If it's not, please let me know.